### PR TITLE
fix(error): wrap in UApp instead of UToaster

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -53,7 +53,6 @@ const [{ data: navigation }, { data: files }] = await Promise.all([
       <LazyUContentSearch
         :files="files"
         :navigation="navigation"
-        shortcut="meta_k"
         :links="navLinks"
         :fuse="{ resultLimit: 42 }"
       />

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app'
 
-defineProps({
-  error: {
-    type: Object as PropType<NuxtError>,
-    required: true
-  }
-})
+defineProps<{
+  error: NuxtError
+}>()
 
 useHead({
   htmlAttrs: {
@@ -39,7 +36,7 @@ const [{ data: navigation }, { data: files }] = await Promise.all([
 </script>
 
 <template>
-  <div>
+  <UApp>
     <AppHeader :links="navLinks" />
 
     <UMain>
@@ -55,13 +52,10 @@ const [{ data: navigation }, { data: files }] = await Promise.all([
     <ClientOnly>
       <LazyUContentSearch
         :files="files"
-        shortcut="meta_k"
         :navigation="navigation"
         :links="navLinks"
         :fuse="{ resultLimit: 42 }"
       />
     </ClientOnly>
-
-    <UToaster />
-  </div>
+  </UApp>
 </template>


### PR DESCRIPTION
`error.vue` replaces `app.vue` entirely on a fatal error, so it was rendering without `UApp` and only got the toaster. That means no tooltip, overlay or locale providers, which `UContentSearch` relies on.

Also drops the now-default `shortcut="meta_k"` on `UContentSearch` and switches `defineProps` to the type-based syntax to match the other templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the error page to display consistently with the application’s interface.
  - Removed the unused keyboard shortcut from content search.
  - Simplified error handling and removed an unnecessary notification element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->