### PR TITLE
fix: strip trailing slash from path before using as asyncData key

### DIFF
--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -2,7 +2,7 @@
 import { withoutTrailingSlash } from 'ufo'
 
 const route = useRoute()
-const routePath = computed(() => withoutTrailingSlash(route.path) || '/')
+const routePath = computed(() => withoutTrailingSlash(route.path))
 
 const { data: page } = await useAsyncData(routePath.value, () =>
   queryCollection('blog').path(routePath.value).first()

--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-const route = useRoute()
+import { withoutTrailingSlash } from 'ufo'
 
-const { data: page } = await useAsyncData(route.path, () =>
-  queryCollection('blog').path(route.path).first()
+const route = useRoute()
+const routePath = computed(() => withoutTrailingSlash(route.path) || '/')
+
+const { data: page } = await useAsyncData(routePath.value, () =>
+  queryCollection('blog').path(routePath.value).first()
 )
 if (!page.value) throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
-const { data: surround } = await useAsyncData(`${route.path}-surround`, () =>
-  queryCollectionItemSurroundings('blog', route.path, {
+const { data: surround } = await useAsyncData(`${routePath.value}-surround`, () =>
+  queryCollectionItemSurroundings('blog', routePath.value, {
     fields: ['description']
   })
 )

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "motion-v": "^2.4.0",
     "nuxt": "^4.5.2",
     "nuxt-og-image": "^6.7.8",
-    "tailwindcss": "^4.3.3"
+    "tailwindcss": "^4.3.3",
+    "ufo": "^1.6.4"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
+      ufo:
+        specifier: ^1.6.4
+        version: 1.6.4
     devDependencies:
       '@nuxt/eslint':
         specifier: ^1.17.0


### PR DESCRIPTION
context: https://github.com/nuxt/nuxt/issues/36111
https://gitlab.com/eu-os/eu-os.gitlab.io/-/merge_requests/19
https://github.com/nuxt/content/pull/3838

on some hosts there may be trailing slashes, which means the route path should never be directly passed to `useAsyncData`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blog article routing by consistently handling paths with or without trailing slashes.
  * Ensured the root blog path resolves correctly without relying on a fallback.
* **Improvements**
  * Enhanced URL handling for a more consistent article-loading experience across supported path formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->